### PR TITLE
React treats component name starting with lowercase letters as DOM tags.

### DIFF
--- a/src/components/ImageCompressor.jsx
+++ b/src/components/ImageCompressor.jsx
@@ -4,7 +4,7 @@ import imageCompression from "browser-image-compression";
 
 import Card from "react-bootstrap/Card";
 
-export default class imageCompressor extends React.Component {
+export default class ImageCompressor extends React.Component {
   constructor() {
     super();
     this.state = {


### PR DESCRIPTION
https://reactjs.org/docs/jsx-in-depth.html#user-defined-components-must-be-capitalized